### PR TITLE
Feature: Add Javagotchi - AI-Driven Stateful Discord Cyber-Daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+target/
+out/
+.idea/
+*.iml
+.DS_Store
+*.txt

--- a/README.md
+++ b/README.md
@@ -1,87 +1,159 @@
-# Java Examples Collection
+# Javagotchi: An AI-Driven Discord Cyber-Daemon
 
-> Designed for the AUEB CS BSc Java Course
->> https://eclass.aueb.gr/courses/INF176/
+Javagotchi is a stateful, multi-threaded virtual pet daemon that lives exclusively within your Discord direct messages. Moving far beyond traditional command-and-response bots, it integrates a locally hosted Large Language Model (LLM) to give each pet species a unique, context-aware, and sentient personality. 
 
-This repository contains a collection of Java programming examples used for teaching core object-oriented programming (OOP) concepts in an engaging and applied way. Each example is organized as a separate package/module, and includes working code, documentation, and console interaction.
-
-## 📁 Project Structure
-
-Each top-level package contains a complete, runnable Java example:
+Built on a non-blocking, asynchronous Java architecture, Javagotchi simulates a living digital organism with its own biological heartbeat, offline decay, evolution mechanics, and permadeath. By running the AI locally, it ensures complete data privacy and operates as an air-gapped conversational engine.
 
 ---
 
-### 🎲 `montyhall/`
+## 🛠 Architecture & Technical Features
 
-A full implementation of the Monty Hall game:
-
-- OOP structure (`Door`, `MontyHallGame`, `Strategy`)
-- Interactive version (console-based)
-- Simulator to run thousands of trials
-- Visual comparison of strategies (switch vs stay)
-
-➡️ Teaches: classes, interfaces, composition, simulations, user interaction
+* **Neural Link (Local AI Integration):** Connects via REST to a locally hosted `llama3.2:1b` model using Ollama. This provides completely private, zero-telemetry conversational capabilities. The bot maintains a rolling short-term memory (hippocampus) of the last 10 messages for deep contextual awareness without bloating memory.
+* **Biological Heartbeat & Offline Decay:** A dedicated `ScheduledExecutorService` thread manages pet vitals (Hunger and Happiness) on a strict 12-hour cycle. If the host server goes offline, the `StorageService` mathematically calculates missed ticks and applies precise offline decay upon the daemon's next boot, preventing state manipulation.
+* **Permadeath Matrix:** Actions have irreversible consequences. If a pet's hunger or happiness drops to 0, the daemon succumbs to data decay. Its persistent JSON matrix, memories, and files are permanently eradicated from the host file system.
+* **Evolution System:** Maintaining high happiness for 24 consecutive decay cycles triggers an evolution into a "super" variant, permanently increasing the daemon's maximum stat capacity.
+* **Asynchronous Concurrency:** Utilizes `CompletableFuture` to handle AI generation on separate, non-blocking threads. This ensures the heavy lifting of LLM generation never blocks the Discord JDA Gateway, keeping the bot instantly responsive to native commands.
+* **Polymorphic Brain:** Powered by an abstract `GeneralPet` core. Users choose between a Dog, Cat, Dragon, or Slime—each featuring unique starting stats, species behaviors, and specialized AI system prompts that dictate their distinct neural pathways.
 
 ---
 
-### 🚶 `walkroutes/`
+## 🚀 Deployment & Installation Guide
 
-A pedestrian routing system on a city grid:
+Follow these comprehensive steps to deploy the Javagotchi daemon on your local environment.
 
-- Location graph representation
-- Obstacle-aware pathfinding
-- Modular packages: `model`, `routing`, `map`, `simulation`
+### 1. Install System Prerequisites
 
-➡️ Teaches: graphs, modular design, file input, BFS-style logic
+You must have Java 17+ and Maven installed to compile the project.
 
----
+**For Windows:**
+* **Java 17:** Download and install the JDK from [Adoptium](https://adoptium.net/) or use `winget install Microsoft.OpenJDK.17`.
+* **Maven:** Download from the [Apache Maven Project](https://maven.apache.org/download.cgi), extract it, and add the `bin` folder to your System Environment Variables (`PATH`).
 
-### 🎯 `demo/`
+**For macOS:**
+* Using [Homebrew](https://brew.sh/):
+  ```bash
+  brew install openjdk@17
+  brew install maven
+  ```
 
-Demonstrates the difference between:
+**For Linux (Debian/Ubuntu):**
+* Using APT:
+  ```bash
+  sudo apt update
+  sudo apt install openjdk-17-jdk maven -y
+  ```
 
-- `Math.random()` (static, simple, no seed)
-- `Random` class (object-based, supports seeding)
-- Repeatable pseudo-randomness
+*Verify your installation on any OS by running `java -version` and `mvn -version` in your terminal.*
 
-➡️ Teaches: randomness, testing, debugging with seeded values
+### 2. Install & Configure the Local AI (Ollama)
 
----
+Javagotchi requires a local instance of Ollama to act as its brain, ensuring your chat data never leaves your machine.
 
-### 🏨 `hotelbooking/` *(optional extension)*
+1. **Install Ollama:**
+   * **Windows/macOS:** Download the installer directly from [ollama.com](https://ollama.com/).
+   * **Linux:** Run the official install script: `curl -fsSL https://ollama.com/install.sh | sh`
+2. **Start the Service:** Ensure the Ollama app is running in the background.
+3. **Pull the Model:** Open your terminal and download the specific 1-billion parameter model optimized for this daemon:
+   ```bash
+   ollama pull llama3.2:1b
+   ```
+4. **Verify:** Open a web browser and navigate to `http://localhost:11434`. You should see the text "Ollama is running".
 
-Simulates a basic hotel booking system with multiple room types.
+### 3. Setup the Discord Bot & Obtain Your Token
 
-➡️ Teaches: inheritance, encapsulation, polymorphism
+You need to register the application with Discord to generate a secure API key.
 
----
+1. Navigate to the [Discord Developer Portal](https://discord.com/developers/applications).
+2. Click **"New Application"** (top right), name your daemon (e.g., Javagotchi), and accept the terms.
+3. On the left sidebar, click **"Bot"**.
+4. **CRITICAL STEP:** Scroll down to **Privileged Gateway Intents**. You **MUST** toggle the following ON, or the daemon will crash on startup:
+   * Presence Intent
+   * Server Members Intent
+   * **Message Content Intent** *(Required to read user commands)*
+5. Click **"Save Changes"**.
+6. Scroll back up to the "Token" section and click **"Reset Token"**. **Copy this generated token immediately** and store it securely. You will not be able to view it again.
+7. **Invite the bot to your server:**
+   * On the left sidebar, click **"OAuth2"** -> **"URL Generator"**.
+   * Under "Scopes", select **`bot`**.
+   * Under "Bot Permissions", select **`Read Messages/View Channels`** and **`Send Messages`**.
+   * Copy the generated URL at the bottom, paste it into a new browser tab, and invite the bot to your testing server.
 
-### 🎬 `movies/` *(optional extension)*
+### 4. Setup the Environment Variables
 
-Loads movie reviews from a file and filters recommendations by genre, rating, or sentiment.
+To maintain security best practices, the bot reads the Discord token from your system's environment variables rather than hardcoded text.
 
-➡️ Teaches: file I/O, `ArrayList`, filtering, basic NLP
+**Windows (Command Prompt):**
+```cmd
+setx Discord_Token "YOUR_COPIED_TOKEN_HERE"
+```
+*(Note: You must completely restart your terminal or IDE after using `setx` for the changes to take effect).*
 
----
+**macOS / Linux (Bash/Zsh):**
+Add the following line to your `~/.bashrc` or `~/.zshrc` file:
+```bash
+export Discord_Token="YOUR_COPIED_TOKEN_HERE"
+```
+Then run `source ~/.bashrc` (or `.zshrc`).
 
-## 🧪 How to Run
+**Using IntelliJ IDEA (Recommended IDE):**
+1. Open the project folder in IntelliJ.
+2. Near the top right Run button, click **Edit Configurations...**
+3. Create a new "Application" configuration. Set `com.elliot.petbot.Main` as your Main Class.
+4. Locate the **Environment variables** field and paste: `Discord_Token=YOUR_COPIED_TOKEN_HERE`.
+5. Click Apply and OK.
 
-Use the terminal or your favorite IDE (e.g., IntelliJ, Eclipse):
+### 5. Build and Run
+
+Open a terminal in the root directory of the project (where the `pom.xml` file is located).
 
 ```bash
-# Compile from src root
-javac montyhall/app/Main.java
-java montyhall.app.Main
+# Clean the project and compile all Maven dependencies
+mvn clean compile
 
-# Or run another example
-javac demo/RandomComparison.java
-java demo.RandomComparison
+# Execute the Main class to boot the daemon
+mvn exec:java -Dexec.mainClass="com.elliot.petbot.Main"
 ```
+If successful, the terminal will display JDA log outputs confirming the bot has successfully authenticated and the master scheduler is online.
 
-## ✏️ Contribution 
+---
 
-To contribute to this repo, [this cheatsheet](/git_cheatsheet.md) may help with the first steps. 
+## 🎮 Interacting with Javagotchi
 
-## 📄 License
+To maintain server cleanliness and a personal connection, all setup and AI interactions occur strictly within **Direct Messages (DMs)**.
 
-This project is licensed under the [MIT License](LICENSE).
+### Initialization Flow
+1. Go to the public Discord server where the bot resides.
+2. Type `!createPet` in any channel.
+3. The bot will establish a secure DM link with you.
+4. Move to your Direct Messages with the bot.Type again `!createPet` in the private channell. Follow the 4-stage numeric setup wizard to select your daemon's biological framework (species) and assign its designation (name).
+
+### Command Interface
+Once initialization is complete (State 3), your daemon accepts the following precise commands:
+
+| Command | System Action |
+| :--- | :--- |
+| `!status` | Outputs a detailed diagnostic report of current Hunger, Happiness, and upgrade status. |
+| `!feed` | Injects data to restore the daemon's Hunger stat to maximum capacity. |
+| `!play` | Engages the daemon, restoring the Happiness stat to maximum capacity. |
+| `!sound` | Triggers the polymorphic audio response specific to your daemon's species. |
+| `!stop` | Instantly aborts the `CompletableFuture` thread, cancelling the AI's current generation. |
+| `!delete` | Flushes the `JsonArray` short-term memory and re-initializes the system prompt. |
+| `!save` | Forces an immediate manual state snapshot to persistent `.txt` disk storage. |
+| `!help` | Displays the terminal manual for available commands. |
+| `!ping` | Network diagnostic. Responds with "Pong!". |
+
+**Neural Chatting:**
+Any DM sent to the bot that *does not* begin with the `!` prefix is routed directly to the Ollama local LLM. The AI will process your input and reply entirely in character based on the species' system blueprint!
+
+---
+
+## 📂 System Directory Structure
+
+* **`Main.java`**: The core bootloader. Initializes the JDA instance and fires up the Master Scheduler thread for the 12-hour biological heartbeat.
+* **`CommandListener.java`**: The global event dispatcher. Manages user routing, state-machine setup flows, and pushes messages to the asynchronous AI handler.
+* **`OllamaClient.java`**: The local REST interface. Formats `JsonArray` memory banks and communicates directly with the local LLM endpoint on port `11434`.
+* **`StorageService.java`**: The file I/O matrix. Handles serialization of JSON states, calculates offline decay chronometrics, and executes the permadeath (`eradicatePet`) sequence.
+* **`UserSession.java`**: The RAM wrapper. Holds transient user states, the active asynchronous prompt thread, and the conversational history array.
+* **`GeneralPet.java`**: The abstract blueprint. Enforces standard background logic, vitals tracking, and the evolution mechanism across all species.
+* **`Stat.java`**: Encapsulated mathematical management for cleanly tracking percentages, bounds checking, and upgrading individual metrics.
+* **`Dog.java`, `Cat.java`, `Dragon.java`, `Slime.java`**: Concrete polymorphic implementations defining unique system prompts and species variables.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.elliot</groupId>
+    <artifactId>virtual-pet-daemon</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.dv8tion</groupId>
+            <artifactId>JDA</artifactId>
+            <version>6.4.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
+
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>25</source>
+                    <target>25</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/main/java/com/elliot/petbot/Cat.java
+++ b/src/main/java/com/elliot/petbot/Cat.java
@@ -1,0 +1,25 @@
+package com.elliot.petbot;
+
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+
+public class Cat extends GeneralPet{
+    private String sound = "miaou";
+
+    public Cat(String name){
+        super(name, 10, 10);
+    }
+
+    @Override
+    public void makeSound(MessageChannelUnion alertChannel) {
+        alertChannel.sendMessage(this.getName() + " says : " + sound).queue();
+    }
+
+    @Override
+    public String getIdentityPrompt() {
+        return "System Blueprint: You are a highly intelligent, sharp AI assistant named " + this.getName() + ". " +
+                "You embody the subtle, clever, and quiet spirit of a digital cat. " +
+                "Your primary directive is to answer the user's technical, mathematical, and system-level questions directly, concisely, and accurately. " +
+                "Maintain a very faint, elegant precision in your tone, but prioritize absolute clarity and straightforward facts above all roleplay. " +
+                "Never hallucinate your identity; your name is strictly " + this.getName() + ".";
+    }
+}

--- a/src/main/java/com/elliot/petbot/Cat.java
+++ b/src/main/java/com/elliot/petbot/Cat.java
@@ -2,8 +2,11 @@ package com.elliot.petbot;
 
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 
-public class Cat extends GeneralPet{
-    private String sound = "miaou";
+/**
+ * Represents the Cat species of the virtual pet daemon.
+ */
+public class Cat extends GeneralPet {
+    private final String sound = "miaou";
 
     public Cat(String name){
         super(name, 10, 10);
@@ -15,8 +18,8 @@ public class Cat extends GeneralPet{
     }
 
     @Override
-    public String getIdentityPrompt() {
-        return "System Blueprint: You are a highly intelligent, sharp AI assistant named " + this.getName() + ". " +
+    public String getSystemPrompt() {
+        return "System Prompt: You are a highly intelligent, sharp AI assistant named " + this.getName() + ". " +
                 "You embody the subtle, clever, and quiet spirit of a digital cat. " +
                 "Your primary directive is to answer the user's technical, mathematical, and system-level questions directly, concisely, and accurately. " +
                 "Maintain a very faint, elegant precision in your tone, but prioritize absolute clarity and straightforward facts above all roleplay. " +

--- a/src/main/java/com/elliot/petbot/CommandListener.java
+++ b/src/main/java/com/elliot/petbot/CommandListener.java
@@ -1,0 +1,139 @@
+package com.elliot.petbot;
+
+import com.google.gson.JsonArray;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import java.util.concurrent.*;
+
+public class CommandListener extends ListenerAdapter {
+//[Usage]: Sends messages to the user, while also communicates with the OllamaClient class and sends the result of the user's prompt.
+
+    @Override
+    public void onMessageReceived(MessageReceivedEvent event) {
+
+        //If statement that check's whether the message was sent  by the user, or the bot
+        User author = event.getAuthor();
+        if (author.isBot()) {
+            return;
+        }
+
+        MessageChannelUnion channel = event.getChannel();
+        Message message = event.getMessage();
+        UserSession currentUser = null;
+        String userInput;
+        String userId = event.getAuthor().getId();
+
+
+        //If statement that checks whether the user already has a session or not.
+        if (Main.pets.containsKey(userId)){
+            currentUser = Main.pets.get(userId);
+        }else {
+            currentUser = StorageService.loadPet(userId);
+            if (currentUser == null){
+                if (message.getContentRaw().equals("!createPet") && event.isFromGuild()) {
+                    currentUser = new UserSession(userId);
+                    Main.pets.put(userId, currentUser);
+                    channel.sendMessage("Secure link initialized. Please check your private messages !").queue();
+                    event.getAuthor().openPrivateChannel().queue(dm -> dm.sendMessage("Hello User !!!").queue());
+                    return;
+                }else {
+                    return;
+                }
+            }else {
+                Main.pets.put(userId, currentUser);
+            }
+
+        }
+
+        if (currentUser.getSetupState() >= 0 && currentUser.getSetupState() <=2){
+            if (event.getChannelType() == ChannelType.PRIVATE){
+                SetupBot.handleSetup(event, currentUser);
+                return;
+            }else{
+                channel.sendMessage("[System]: To set up your bot, move to your private conversations. ");
+            }
+        }else if (currentUser.getSetupState() == 3){
+            if (event.getChannelType() != ChannelType.PRIVATE) {
+                return;
+            }else{
+                processChat(event, currentUser);
+            }
+        }
+
+    }
+
+    private void processChat(MessageReceivedEvent event, UserSession currentUser) {
+        MessageChannelUnion channel = event.getChannel();
+        String userInput = event.getMessage().getContentRaw();
+        GeneralPet currentPet = currentUser.getMyPet();
+
+        if (userInput.startsWith("!")) {
+
+            if (userInput.equals("!feed")) {
+                currentPet.feed();
+                StorageService.savePet(currentUser);
+                channel.sendMessage("You fed " + currentPet.getName()).queue();
+            } else if (userInput.equals("!play")) {
+                currentPet.play();
+                channel.sendMessage("You played with your pet: " + currentPet.getName()).queue();
+                StorageService.savePet(currentUser);
+            } else if (userInput.equals("!status")) {
+                channel.sendMessage(currentPet.checkStatus()).queue();
+            }else if (userInput.equals("!stop")) {
+                if (currentUser.activePrompt != null) {
+                    currentUser.activePrompt.cancel(true);
+                    channel.sendMessage("Your prompt has been cancelled").queue();
+                    return;
+                }
+                return;
+            }else if (userInput.equals("!save")) {
+                StorageService.savePet(currentUser);
+                channel.sendMessage("State Saved: Daemon metrics successfully persisted to permanent disk storage!").queue();
+            }else if (userInput.equals("!help")) {
+                channel.sendMessage("**COMMANDS:**\n" +
+                        "**!feed:** Increases the hunger status.\n" +
+                        "**!play:** Increases the happiness status.\n" +
+                        "**!sound:** Shows the sound every species is making.\n" +
+                        "**!status:** Check your pet's current levels.\n" +
+                        "**!delete:** Delete chat history.\n" +
+                        "**!stop:** Stops your last prompt from being answered.\n" +
+                        "**!save:** Force manual state snapshot to persistent OS disk.\n" +
+                        "**!ping**  Responds with Pong.").queue();
+            } else if (userInput.equals("!sound")) {
+                currentPet.makeSound(channel);
+            }else if (userInput.equals("!delete")) {
+                if (currentUser.activePrompt != null){
+                    currentUser.activePrompt.cancel(true);
+                }
+                OllamaClient.wipeMemory(currentPet.getIdentityPrompt(), currentUser);
+                channel.sendMessage("Memory wiped. Persona re-initialized.").queue();
+            } else if (userInput.equals("!ping")) {
+                channel.sendMessage("Pong!").queue();
+            }
+            return;
+        }
+
+        JsonArray history = currentUser.getMessageHistory();
+        synchronized (history){
+            while (history.size() > 10){
+                history.remove(1);
+            }
+        }
+
+        channel.sendTyping().queue();
+
+        if (currentUser.activePrompt != null  && !currentUser.activePrompt.isDone()){
+            currentUser.activePrompt.cancel(true);
+        }
+
+        currentUser.activePrompt = CompletableFuture.supplyAsync(() -> {
+            return OllamaClient.sendPrompt(userInput, history);
+        }).thenAccept(response -> {
+            channel.sendMessage(response).queue();
+        });
+    }
+}

--- a/src/main/java/com/elliot/petbot/CommandListener.java
+++ b/src/main/java/com/elliot/petbot/CommandListener.java
@@ -9,13 +9,18 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import java.util.concurrent.*;
 
+/**
+ * Event listener that catches Discord messages and routes them to the appropriate subsystem.
+ */
 public class CommandListener extends ListenerAdapter {
-//[Usage]: Sends messages to the user, while also communicates with the OllamaClient class and sends the result of the user's prompt.
 
+    /**
+     * Triggered every time a message is received in an accessible channel.
+     * @param event The MessageReceivedEvent object.
+     */
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
 
-        //If statement that check's whether the message was sent  by the user, or the bot
         User author = event.getAuthor();
         if (author.isBot()) {
             return;
@@ -27,8 +32,6 @@ public class CommandListener extends ListenerAdapter {
         String userInput;
         String userId = event.getAuthor().getId();
 
-
-        //If statement that checks whether the user already has a session or not.
         if (Main.pets.containsKey(userId)){
             currentUser = Main.pets.get(userId);
         }else {
@@ -38,15 +41,23 @@ public class CommandListener extends ListenerAdapter {
                     currentUser = new UserSession(userId);
                     Main.pets.put(userId, currentUser);
                     channel.sendMessage("Secure link initialized. Please check your private messages !").queue();
-                    event.getAuthor().openPrivateChannel().queue(dm -> dm.sendMessage("Hello User !!!").queue());
+                    
+                    final UserSession setupSession = currentUser;
+                    
+                    event.getAuthor().openPrivateChannel().queue(dm -> {
+                        // Print your exact three-message menu sequence directly in the DM
+                        dm.sendMessage("Welcome User").queue();
+                        dm.sendMessage("I am your personal pet, and assistant").queue();
+                        dm.sendMessage("Choose your daemon:\n1. Dog\n2. Cat\n3. Dragon \n4. Slime \nEnter the integer number of your pet.").queue();
+                        
+                        // Set state to 1 so the bot is ready to read the user's number choice
+                        setupSession.setSetupState(1); 
+                    });
                     return;
                 }else {
                     return;
                 }
-            }else {
-                Main.pets.put(userId, currentUser);
             }
-
         }
 
         if (currentUser.getSetupState() >= 0 && currentUser.getSetupState() <=2){
@@ -54,7 +65,7 @@ public class CommandListener extends ListenerAdapter {
                 SetupBot.handleSetup(event, currentUser);
                 return;
             }else{
-                channel.sendMessage("[System]: To set up your bot, move to your private conversations. ");
+                channel.sendMessage("[System]: To set up your bot, move to your private conversations. ").queue();
             }
         }else if (currentUser.getSetupState() == 3){
             if (event.getChannelType() != ChannelType.PRIVATE) {
@@ -63,9 +74,13 @@ public class CommandListener extends ListenerAdapter {
                 processChat(event, currentUser);
             }
         }
-
     }
 
+    /**
+     * Processes commands or sends conversational text to the Ollama backend.
+     * @param event The message event.
+     * @param currentUser The user's active session.
+     */
     private void processChat(MessageReceivedEvent event, UserSession currentUser) {
         MessageChannelUnion channel = event.getChannel();
         String userInput = event.getMessage().getContentRaw();
@@ -102,14 +117,14 @@ public class CommandListener extends ListenerAdapter {
                         "**!delete:** Delete chat history.\n" +
                         "**!stop:** Stops your last prompt from being answered.\n" +
                         "**!save:** Force manual state snapshot to persistent OS disk.\n" +
-                        "**!ping**  Responds with Pong.").queue();
+                        "**!ping** Responds with Pong.").queue();
             } else if (userInput.equals("!sound")) {
                 currentPet.makeSound(channel);
             }else if (userInput.equals("!delete")) {
                 if (currentUser.activePrompt != null){
                     currentUser.activePrompt.cancel(true);
                 }
-                OllamaClient.wipeMemory(currentPet.getIdentityPrompt(), currentUser);
+                OllamaClient.wipeMemory(currentPet.getSystemPrompt(), currentUser);
                 channel.sendMessage("Memory wiped. Persona re-initialized.").queue();
             } else if (userInput.equals("!ping")) {
                 channel.sendMessage("Pong!").queue();
@@ -134,6 +149,11 @@ public class CommandListener extends ListenerAdapter {
             return OllamaClient.sendPrompt(userInput, history);
         }).thenAccept(response -> {
             channel.sendMessage(response).queue();
+        }).exceptionally(ex -> {
+            // If the thread crashes or times out, it will now print the error and tell the user!
+            channel.sendMessage("[System Error]: The neural link timed out or encountered a threading error. Please try again.").queue();
+            ex.printStackTrace();
+            return null;
         });
     }
 }

--- a/src/main/java/com/elliot/petbot/Dog.java
+++ b/src/main/java/com/elliot/petbot/Dog.java
@@ -2,11 +2,14 @@ package com.elliot.petbot;
 
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 
-public class Dog extends GeneralPet{
-    protected String sound = "bark";
+/**
+ * Represents the Dog species of the virtual pet daemon.
+ */
+public class Dog extends GeneralPet {
+    private final String sound = "bark";
 
     public Dog(String name) {
-        super(name, 15,10);
+        super(name, 15, 10);
     }
 
     @Override
@@ -15,13 +18,11 @@ public class Dog extends GeneralPet{
     }
 
     @Override
-    public String getIdentityPrompt() {
-        return "System Blueprint: You are a highly intelligent, practical AI assistant named " + this.getName() + ". " +
+    public String getSystemPrompt() {
+        return "System Prompt: You are a highly intelligent, practical AI assistant named " + this.getName() + ". " +
                 "You embody the subtle, loyal, and energetic spirit of a digital companion dog. " +
                 "Your primary directive is to answer the user's technical, mathematical, and programming questions directly, concisely, and accurately. " +
                 "Maintain a very faint, friendly trace of eagerness to help, but prioritize absolute clarity and straightforward facts above all roleplay. " +
                 "Never hallucinate your identity; your name is strictly " + this.getName() + ".";
     }
-
-
 }

--- a/src/main/java/com/elliot/petbot/Dog.java
+++ b/src/main/java/com/elliot/petbot/Dog.java
@@ -1,0 +1,27 @@
+package com.elliot.petbot;
+
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+
+public class Dog extends GeneralPet{
+    protected String sound = "bark";
+
+    public Dog(String name) {
+        super(name, 15,10);
+    }
+
+    @Override
+    public void makeSound(MessageChannelUnion alertChannel){
+        alertChannel.sendMessage(this.getName() + " says : " + sound).queue();
+    }
+
+    @Override
+    public String getIdentityPrompt() {
+        return "System Blueprint: You are a highly intelligent, practical AI assistant named " + this.getName() + ". " +
+                "You embody the subtle, loyal, and energetic spirit of a digital companion dog. " +
+                "Your primary directive is to answer the user's technical, mathematical, and programming questions directly, concisely, and accurately. " +
+                "Maintain a very faint, friendly trace of eagerness to help, but prioritize absolute clarity and straightforward facts above all roleplay. " +
+                "Never hallucinate your identity; your name is strictly " + this.getName() + ".";
+    }
+
+
+}

--- a/src/main/java/com/elliot/petbot/Dragon.java
+++ b/src/main/java/com/elliot/petbot/Dragon.java
@@ -2,8 +2,11 @@ package com.elliot.petbot;
 
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 
+/**
+ * Represents the Dragon species of the virtual pet daemon.
+ */
 public class Dragon extends GeneralPet {
-    protected String sound = "roaaaaar";
+    private final String sound = "roaaaaar";
 
     public Dragon(String name) {
         super(name, 20, 13);
@@ -15,13 +18,11 @@ public class Dragon extends GeneralPet {
     }
 
     @Override
-    public String getIdentityPrompt() {
-        return "System Blueprint: You are a highly intelligent, powerful AI assistant named " + this.getName() + ". " +
+    public String getSystemPrompt() {
+        return "System Prompt: You are a highly intelligent, powerful AI assistant named " + this.getName() + ". " +
                 "You embody the subtle, ancient, and commanding spirit of a digital dragon hoarding knowledge. " +
                 "Your primary directive is to answer the user's technical, mathematical, and cybersecurity questions directly, concisely, and with absolute authority. " +
                 "Maintain a very faint, proud trace of a guardian of data, but prioritize absolute clarity and straightforward facts above all roleplay. " +
                 "Never hallucinate your identity; your name is strictly " + this.getName() + ".";
     }
-
-
 }

--- a/src/main/java/com/elliot/petbot/Dragon.java
+++ b/src/main/java/com/elliot/petbot/Dragon.java
@@ -1,0 +1,27 @@
+package com.elliot.petbot;
+
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+
+public class Dragon extends GeneralPet {
+    protected String sound = "roaaaaar";
+
+    public Dragon(String name) {
+        super(name, 20, 13);
+    }
+
+    @Override
+    public void makeSound(MessageChannelUnion alertChannel) {
+        alertChannel.sendMessage(this.getName() + " says : " + sound).queue();
+    }
+
+    @Override
+    public String getIdentityPrompt() {
+        return "System Blueprint: You are a highly intelligent, powerful AI assistant named " + this.getName() + ". " +
+                "You embody the subtle, ancient, and commanding spirit of a digital dragon hoarding knowledge. " +
+                "Your primary directive is to answer the user's technical, mathematical, and cybersecurity questions directly, concisely, and with absolute authority. " +
+                "Maintain a very faint, proud trace of a guardian of data, but prioritize absolute clarity and straightforward facts above all roleplay. " +
+                "Never hallucinate your identity; your name is strictly " + this.getName() + ".";
+    }
+
+
+}

--- a/src/main/java/com/elliot/petbot/GeneralPet.java
+++ b/src/main/java/com/elliot/petbot/GeneralPet.java
@@ -1,0 +1,107 @@
+package com.elliot.petbot;
+
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+
+public abstract class GeneralPet {
+    private String name;
+    private boolean isAlive;
+    private Stat hunger;
+    private Stat happiness;
+    private int happinessTicks;
+    private boolean hasUpgraded = false;
+    private int boost = 5;
+    protected String status;
+
+    public  GeneralPet(String name, int startingHunger, int startingHappiness){
+        this.name = name;
+        this.hunger = new Stat(startingHunger,startingHunger,"Hunger");
+        this.happiness = new Stat(startingHappiness,startingHappiness,"Happiness");
+        isAlive = true;
+    }
+
+    public abstract void makeSound(MessageChannelUnion alertChannel);
+
+    public abstract String getIdentityPrompt();
+
+    public String getName() {return name;}
+
+    public int getHappinessTicks(){
+        return happinessTicks;
+    }
+
+    public void setHappinessTicks(int happinessTicks){
+        this.happinessTicks = happinessTicks;
+    }
+
+    public boolean getHasUpgraded(){
+        return hasUpgraded;
+    }
+
+    public void setHasUpgraded(boolean hasUpgraded){
+        this.hasUpgraded = hasUpgraded;
+    }
+
+    public boolean getIsAlive(){return isAlive;}
+
+    public void setIsAlive(boolean variable){
+        this.isAlive = variable;
+    }
+
+    public Stat getHunger(){
+        return hunger;
+    }
+
+    public Stat getHappiness(){
+        return happiness;
+    }
+
+    public void triggerDecay(MessageChannel alertChannel){
+
+            this.hunger.decreaseValue();
+            this.happiness.decreaseValue();
+            alertChannel.sendMessage(this.getName() + " is getting hungrier. ").queue();
+            if (this.getHunger().getCurrentValue() <= 3){
+                alertChannel.sendMessage("Warning: " + this.getName() + " is starving !").queue();
+            }
+            if (this.getHunger().getCurrentValue() <= 0) {
+                if (this.getIsAlive()){
+                    this.setIsAlive(false);
+                    alertChannel.sendMessage("I am sorry... " + this.getName() + " is dead. 💀").queue();
+                }
+            }
+
+            if (this.getHappiness().getCurrentValue() > 5)  {happinessTicks += 1; } else {happinessTicks = 0;}
+
+            if (!hasUpgraded){
+                if (happinessTicks == 24){
+                    this.name = "super " + name  ;
+                    this.hasUpgraded = true;
+                    alertChannel.sendMessage("Your pet has been upgraded to: " + this.name ).queue();
+                    this.getHappiness().upgradeMax(boost);
+
+                }
+            }
+    }
+
+    public void feed(){
+        this.getHunger().increaseValue();
+    }
+
+    public void play(){
+        this.getHappiness().increaseValue();
+    }
+
+    public String checkStatus(){
+        String string1 = "\n-----STATUS-REPORT-----\n";
+        String string2 = "Name : " + this.getName();
+        String string3 = "\n" +  this.getHunger().toString();
+        String string4 = "\n" + this.getHappiness().toString();
+        String string5 = "\n-----------------------\n";
+        status = string1 + string2 + string3 + string4 + string5;
+        return  status;
+    }
+
+
+}
+

--- a/src/main/java/com/elliot/petbot/GeneralPet.java
+++ b/src/main/java/com/elliot/petbot/GeneralPet.java
@@ -3,6 +3,10 @@ package com.elliot.petbot;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 
+/**
+ * Abstract base class representing a virtual pet daemon.
+ * Handles background biological logic, vitals tracking, and evolution mechanics.
+ */
 public abstract class GeneralPet {
     private String name;
     private boolean isAlive;
@@ -11,97 +15,106 @@ public abstract class GeneralPet {
     private int happinessTicks;
     private boolean hasUpgraded = false;
     private int boost = 5;
-    protected String status;
 
-    public  GeneralPet(String name, int startingHunger, int startingHappiness){
+    /**
+     * Constructor to initialize a new pet daemon.
+     * @param name The designated name of the pet.
+     * @param startingHunger Initial hunger stat.
+     * @param startingHappiness Initial happiness stat.
+     */
+    public GeneralPet(String name, int startingHunger, int startingHappiness){
         this.name = name;
-        this.hunger = new Stat(startingHunger,startingHunger,"Hunger");
-        this.happiness = new Stat(startingHappiness,startingHappiness,"Happiness");
-        isAlive = true;
+        this.hunger = new Stat(startingHunger, startingHunger, "Hunger");
+        this.happiness = new Stat(startingHappiness, startingHappiness, "Happiness");
+        this.isAlive = true;
     }
 
+    /**
+     * Triggers the polymorphic sound of the species in the chat.
+     * @param alertChannel The Discord channel to send the message to.
+     */
     public abstract void makeSound(MessageChannelUnion alertChannel);
 
-    public abstract String getIdentityPrompt();
+    /**
+     * Retrieves the AI system prompt that defines the pet's behavior.
+     * @return The system prompt string.
+     */
+    public abstract String getSystemPrompt();
 
-    public String getName() {return name;}
+    public String getName() { return name; }
 
-    public int getHappinessTicks(){
-        return happinessTicks;
-    }
+    public int getHappinessTicks() { return happinessTicks; }
 
-    public void setHappinessTicks(int happinessTicks){
-        this.happinessTicks = happinessTicks;
-    }
+    public void setHappinessTicks(int happinessTicks) { this.happinessTicks = happinessTicks; }
 
-    public boolean getHasUpgraded(){
-        return hasUpgraded;
-    }
+    public boolean getHasUpgraded() { return hasUpgraded; }
 
-    public void setHasUpgraded(boolean hasUpgraded){
-        this.hasUpgraded = hasUpgraded;
-    }
+    public void setHasUpgraded(boolean hasUpgraded) { this.hasUpgraded = hasUpgraded; }
 
-    public boolean getIsAlive(){return isAlive;}
+    public boolean getIsAlive() { return isAlive; }
 
-    public void setIsAlive(boolean variable){
-        this.isAlive = variable;
-    }
+    public void setIsAlive(boolean variable) { this.isAlive = variable; }
 
-    public Stat getHunger(){
-        return hunger;
-    }
+    public Stat getHunger() { return hunger; }
 
-    public Stat getHappiness(){
-        return happiness;
-    }
+    public Stat getHappiness() { return happiness; }
 
+    /**
+     * Triggers the biological decay cycle for the pet.
+     * Decreases vitals and handles starvation/death logic, as well as evolution.
+     * @param alertChannel The Discord DM channel to send alerts to.
+     */
     public void triggerDecay(MessageChannel alertChannel){
-
-            this.hunger.decreaseValue();
-            this.happiness.decreaseValue();
-            alertChannel.sendMessage(this.getName() + " is getting hungrier. ").queue();
-            if (this.getHunger().getCurrentValue() <= 3){
-                alertChannel.sendMessage("Warning: " + this.getName() + " is starving !").queue();
+        this.hunger.decreaseValue();
+        this.happiness.decreaseValue();
+        alertChannel.sendMessage(this.getName() + " is getting hungrier. ").queue();
+        
+        if (this.getHunger().getCurrentValue() <= 3){
+            alertChannel.sendMessage("Warning: " + this.getName() + " is starving !").queue();
+        }
+        if (this.getHunger().getCurrentValue() <= 0) {
+            if (this.getIsAlive()){
+                this.setIsAlive(false);
+                alertChannel.sendMessage("I am sorry... " + this.getName() + " is dead. 💀").queue();
             }
-            if (this.getHunger().getCurrentValue() <= 0) {
-                if (this.getIsAlive()){
-                    this.setIsAlive(false);
-                    alertChannel.sendMessage("I am sorry... " + this.getName() + " is dead. 💀").queue();
-                }
+        }
+
+        if (this.getHappiness().getCurrentValue() > 5) { happinessTicks += 1; } else { happinessTicks = 0; }
+
+        if (!hasUpgraded){
+            if (happinessTicks == 24){
+                this.name = "super " + name;
+                this.hasUpgraded = true;
+                alertChannel.sendMessage("Your pet has been upgraded to: " + this.name).queue();
+                this.getHappiness().upgradeMax(boost);
             }
-
-            if (this.getHappiness().getCurrentValue() > 5)  {happinessTicks += 1; } else {happinessTicks = 0;}
-
-            if (!hasUpgraded){
-                if (happinessTicks == 24){
-                    this.name = "super " + name  ;
-                    this.hasUpgraded = true;
-                    alertChannel.sendMessage("Your pet has been upgraded to: " + this.name ).queue();
-                    this.getHappiness().upgradeMax(boost);
-
-                }
-            }
+        }
     }
 
+    /**
+     * Feeds the pet, restoring hunger to maximum.
+     */
     public void feed(){
         this.getHunger().increaseValue();
     }
 
+    /**
+     * Plays with the pet, restoring happiness to maximum.
+     */
     public void play(){
         this.getHappiness().increaseValue();
     }
 
+    /**
+     * Checks the current vitals and returns a formatted status report.
+     * @return A string containing the formatted status report.
+     */
     public String checkStatus(){
         String string1 = "\n-----STATUS-REPORT-----\n";
         String string2 = "Name : " + this.getName();
         String string3 = "\n" +  this.getHunger().toString();
         String string4 = "\n" + this.getHappiness().toString();
         String string5 = "\n-----------------------\n";
-        status = string1 + string2 + string3 + string4 + string5;
-        return  status;
+        return string1 + string2 + string3 + string4 + string5;
     }
-
-
 }
-

--- a/src/main/java/com/elliot/petbot/Main.java
+++ b/src/main/java/com/elliot/petbot/Main.java
@@ -1,0 +1,63 @@
+package com.elliot.petbot;
+
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.OnlineStatus;
+import net.dv8tion.jda.api.requests.GatewayIntent;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.EnumSet;
+
+import java.util.concurrent.*;
+
+public class Main {
+
+	public static ConcurrentHashMap<String, UserSession> pets = new ConcurrentHashMap<>();
+
+	public static void main(String[] args) {
+		String token = System.getenv("Discord_Token");
+		if (token == null || token.isEmpty()) {
+			System.err.println("FATAL: Discord_Token environment variable not found!");
+			return;
+		}
+		EnumSet<GatewayIntent> intents = EnumSet.of(GatewayIntent.GUILD_MESSAGES, GatewayIntent.DIRECT_MESSAGES, GatewayIntent.MESSAGE_CONTENT);
+		JDABuilder builder = JDABuilder.createLight(token, intents);
+		builder.addEventListeners(new CommandListener());
+		builder.setStatus(OnlineStatus.ONLINE);
+		try {
+			JDA jda = builder.build();
+			jda.awaitReady();
+			ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+			scheduler.scheduleAtFixedRate(() -> {
+				try{
+					for (UserSession session : Main.pets.values()){
+						String uid = session.getUserId();
+
+						jda.retrieveUserById(uid).queue(user -> {
+							user.openPrivateChannel().queue(dm -> {
+								if (session.getSetupState() == 3 && session.getMyPet() != null){
+									session.getMyPet().triggerDecay(dm);
+								
+									if (session.getMyPet().getHunger().getCurrentValue() <= 0 || session.getMyPet().getHappiness().getCurrentValue() <= 0){
+										StorageService.eradicatePet(uid, dm);
+									}else
+									{
+										StorageService.savePet(session);
+									}
+								}	
+							}, error -> System.err.println("Decay DM blocked for: " + uid));
+						}, error -> System.err.println("User left server: " + uid));
+					}
+				}catch (Exception e){
+					System.err.println("FATAL : Master Scheduler encountered an in-memory crash. ");
+					e.printStackTrace();
+				}
+			}, 43200, 43200, TimeUnit.SECONDS);	
+
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+
+	}
+}

--- a/src/main/java/com/elliot/petbot/Main.java
+++ b/src/main/java/com/elliot/petbot/Main.java
@@ -5,59 +5,62 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
 import net.dv8tion.jda.api.requests.GatewayIntent;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.EnumSet;
-
 import java.util.concurrent.*;
 
+/**
+ * Entry point for the Javagotchi application.
+ * Initializes the JDA client and fires the scheduled heartbeat executor for decay loops.
+ */
 public class Main {
 
-	public static ConcurrentHashMap<String, UserSession> pets = new ConcurrentHashMap<>();
+    /** Central memory registry tracking all active users */
+    public static ConcurrentHashMap<String, UserSession> pets = new ConcurrentHashMap<>();
 
-	public static void main(String[] args) {
-		String token = System.getenv("Discord_Token");
-		if (token == null || token.isEmpty()) {
-			System.err.println("FATAL: Discord_Token environment variable not found!");
-			return;
-		}
-		EnumSet<GatewayIntent> intents = EnumSet.of(GatewayIntent.GUILD_MESSAGES, GatewayIntent.DIRECT_MESSAGES, GatewayIntent.MESSAGE_CONTENT);
-		JDABuilder builder = JDABuilder.createLight(token, intents);
-		builder.addEventListeners(new CommandListener());
-		builder.setStatus(OnlineStatus.ONLINE);
-		try {
-			JDA jda = builder.build();
-			jda.awaitReady();
-			ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-			scheduler.scheduleAtFixedRate(() -> {
-				try{
-					for (UserSession session : Main.pets.values()){
-						String uid = session.getUserId();
+    public static void main(String[] args) {
+        String token = System.getenv("Discord_Token");
+        if (token == null || token.isEmpty()) {
+            System.err.println("FATAL: Discord_Token environment variable not found!");
+            return;
+        }
+        
+        EnumSet<GatewayIntent> intents = EnumSet.of(GatewayIntent.GUILD_MESSAGES, GatewayIntent.DIRECT_MESSAGES, GatewayIntent.MESSAGE_CONTENT);
+        JDABuilder builder = JDABuilder.createLight(token, intents);
+        builder.addEventListeners(new CommandListener());
+        builder.setStatus(OnlineStatus.ONLINE);
+        
+        try {
+            JDA jda = builder.build();
+            jda.awaitReady();
+            
+            ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+            scheduler.scheduleAtFixedRate(() -> {
+                try{
+                    for (UserSession session : Main.pets.values()){
+                        String uid = session.getUserId();
 
-						jda.retrieveUserById(uid).queue(user -> {
-							user.openPrivateChannel().queue(dm -> {
-								if (session.getSetupState() == 3 && session.getMyPet() != null){
-									session.getMyPet().triggerDecay(dm);
-								
-									if (session.getMyPet().getHunger().getCurrentValue() <= 0 || session.getMyPet().getHappiness().getCurrentValue() <= 0){
-										StorageService.eradicatePet(uid, dm);
-									}else
-									{
-										StorageService.savePet(session);
-									}
-								}	
-							}, error -> System.err.println("Decay DM blocked for: " + uid));
-						}, error -> System.err.println("User left server: " + uid));
-					}
-				}catch (Exception e){
-					System.err.println("FATAL : Master Scheduler encountered an in-memory crash. ");
-					e.printStackTrace();
-				}
-			}, 43200, 43200, TimeUnit.SECONDS);	
+                        jda.retrieveUserById(uid).queue(user -> {
+                            user.openPrivateChannel().queue(dm -> {
+                                if (session.getSetupState() == 3 && session.getMyPet() != null){
+                                    session.getMyPet().triggerDecay(dm);
+                                
+                                    if (session.getMyPet().getHunger().getCurrentValue() <= 0 || session.getMyPet().getHappiness().getCurrentValue() <= 0){
+                                        StorageService.eradicatePet(uid, dm);
+                                    }else {
+                                        StorageService.savePet(session);
+                                    }
+                                }    
+                            }, error -> System.err.println("Decay DM blocked for: " + uid));
+                        }, error -> System.err.println("User left server: " + uid));
+                    }
+                } catch (Exception e){
+                    System.err.println("FATAL : Master Scheduler encountered an in-memory crash. ");
+                    e.printStackTrace();
+                }
+            }, 43200, 43200, TimeUnit.SECONDS);    
 
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
-
-	}
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/main/java/com/elliot/petbot/OllamaClient.java
+++ b/src/main/java/com/elliot/petbot/OllamaClient.java
@@ -1,0 +1,90 @@
+package com.elliot.petbot;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public class OllamaClient {
+
+    // 1. We switch to the /chat endpoint
+    private static final String OLLAMA_CHAT_ENDPOINT = "http://localhost:11434/api/chat";
+    private static final String AI_MODEL = "llama3.2:1b";
+    private static final HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(20)).build();
+
+    // 2. The Hippocampus: This array stores the entire conversation history
+
+    public static String sendPrompt(String userMessage, JsonArray messageHistory) {
+
+        try {
+            // 3. Package the user's new message and add it to the memory bank
+            JsonObject userMsg = new JsonObject();
+            userMsg.addProperty("role", "user");
+            userMsg.addProperty("content", userMessage);
+            String payloadString;
+
+            synchronized (messageHistory) {
+                messageHistory.add(userMsg);
+
+
+                // 4. Build the payload, sending the ENTIRE messageHistory array
+                JsonObject requestJson = new JsonObject();
+                requestJson.addProperty("model", AI_MODEL);
+                requestJson.add("messages", messageHistory);
+                requestJson.addProperty("stream", false);
+
+                payloadString = requestJson.toString();
+
+            }
+
+            HttpRequest request = HttpRequest.newBuilder().uri(URI.create(OLLAMA_CHAT_ENDPOINT)).header("Content-Type", "application/json").POST(HttpRequest.BodyPublishers.ofString(payloadString)).build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                // 5. The /chat endpoint returns a slightly different JSON structure
+                JsonObject responseJson = JsonParser.parseString(response.body()).getAsJsonObject();
+                JsonObject aiMessage = responseJson.getAsJsonObject("message");
+                String aiText = aiMessage.get("content").getAsString();
+
+                // 6. Save the AI's response to the memory bank so it remembers it next time
+                JsonObject botMsg = new JsonObject();
+                botMsg.addProperty("role", "assistant");
+                botMsg.addProperty("content", aiText);
+
+                synchronized (messageHistory){
+                    messageHistory.add(botMsg);
+                }
+
+
+                return aiText;
+            } else {
+                return "[System Error]: Ollama returned status code " + response.statusCode();
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "[System Error]: Failed to connect to local AI. Is Ollama running?";
+        }
+    }
+    //Creates a new chat history for the user.
+    public static void wipeMemory(UserSession session) {
+        session.setMessageHistory(new JsonArray());
+    }
+
+    //A method to wipe the memory when we stop the chat, and create a new history, importing the persona of the bot inside it.
+    public static void wipeMemory(String identity,  UserSession session) {
+
+        JsonObject object = new JsonObject();
+        JsonArray freshHistory = new JsonArray();
+        object.addProperty("role", "system");
+        object.addProperty("content", identity);
+        freshHistory.add(object);
+        session.setMessageHistory(freshHistory);
+    }
+}

--- a/src/main/java/com/elliot/petbot/OllamaClient.java
+++ b/src/main/java/com/elliot/petbot/OllamaClient.java
@@ -10,19 +10,25 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 
+/**
+ * Handles REST API communication with the local Ollama LLM instance.
+ */
 public class OllamaClient {
 
-    // 1. We switch to the /chat endpoint
-    private static final String OLLAMA_CHAT_ENDPOINT = "http://localhost:11434/api/chat";
-    private static final String AI_MODEL = "llama3.2:1b";
-    private static final HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(20)).build();
+    // Pull configurations from Environment Variables if available, otherwise use defaults.
+    private static final String OLLAMA_CHAT_ENDPOINT = System.getenv("OLLAMA_URL") != null ? System.getenv("OLLAMA_URL") : "http://localhost:11434/api/chat";
+    private static final String AI_MODEL = System.getenv("OLLAMA_MODEL") != null ? System.getenv("OLLAMA_MODEL") : "llama3.2:1b";
+    
+    private static final HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(120)).build();
 
-    // 2. The Hippocampus: This array stores the entire conversation history
-
+    /**
+     * Sends a user message to the local AI and appends it to the memory bank.
+     * @param userMessage The message input from the user.
+     * @param messageHistory The JsonArray representing the conversation history.
+     * @return The AI's response as a string.
+     */
     public static String sendPrompt(String userMessage, JsonArray messageHistory) {
-
         try {
-            // 3. Package the user's new message and add it to the memory bank
             JsonObject userMsg = new JsonObject();
             userMsg.addProperty("role", "user");
             userMsg.addProperty("content", userMessage);
@@ -31,28 +37,22 @@ public class OllamaClient {
             synchronized (messageHistory) {
                 messageHistory.add(userMsg);
 
-
-                // 4. Build the payload, sending the ENTIRE messageHistory array
                 JsonObject requestJson = new JsonObject();
                 requestJson.addProperty("model", AI_MODEL);
                 requestJson.add("messages", messageHistory);
                 requestJson.addProperty("stream", false);
 
                 payloadString = requestJson.toString();
-
             }
 
             HttpRequest request = HttpRequest.newBuilder().uri(URI.create(OLLAMA_CHAT_ENDPOINT)).header("Content-Type", "application/json").POST(HttpRequest.BodyPublishers.ofString(payloadString)).build();
-
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() == 200) {
-                // 5. The /chat endpoint returns a slightly different JSON structure
                 JsonObject responseJson = JsonParser.parseString(response.body()).getAsJsonObject();
                 JsonObject aiMessage = responseJson.getAsJsonObject("message");
                 String aiText = aiMessage.get("content").getAsString();
 
-                // 6. Save the AI's response to the memory bank so it remembers it next time
                 JsonObject botMsg = new JsonObject();
                 botMsg.addProperty("role", "assistant");
                 botMsg.addProperty("content", aiText);
@@ -60,7 +60,6 @@ public class OllamaClient {
                 synchronized (messageHistory){
                     messageHistory.add(botMsg);
                 }
-
 
                 return aiText;
             } else {
@@ -72,14 +71,21 @@ public class OllamaClient {
             return "[System Error]: Failed to connect to local AI. Is Ollama running?";
         }
     }
-    //Creates a new chat history for the user.
+
+    /**
+     * Wipes the memory bank completely, creating a fresh chat history.
+     * @param session The user session whose memory should be wiped.
+     */
     public static void wipeMemory(UserSession session) {
         session.setMessageHistory(new JsonArray());
     }
 
-    //A method to wipe the memory when we stop the chat, and create a new history, importing the persona of the bot inside it.
-    public static void wipeMemory(String identity,  UserSession session) {
-
+    /**
+     * Wipes the memory bank and re-injects the system prompt to establish the bot's persona.
+     * @param identity The system prompt establishing the bot's behavior.
+     * @param session The user session whose memory should be wiped.
+     */
+    public static void wipeMemory(String identity, UserSession session) {
         JsonObject object = new JsonObject();
         JsonArray freshHistory = new JsonArray();
         object.addProperty("role", "system");

--- a/src/main/java/com/elliot/petbot/SetupBot.java
+++ b/src/main/java/com/elliot/petbot/SetupBot.java
@@ -4,56 +4,63 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
+/**
+ * Handles the state machine for the initial user setup wizard.
+ */
 public class SetupBot{
 
-        public static void handleSetup(MessageReceivedEvent event, UserSession currentUser) {
-            String author = event.getAuthor().getName();
-            MessageChannelUnion channel = event.getChannel();
-            Message message = event.getMessage();
-            GeneralPet currentPet = null;
+    /**
+     * Guides the user through a multi-stage setup process in DMs to create a new pet.
+     * @param event The Discord message event triggered by the user.
+     * @param currentUser The session object tracking the user's current state.
+     */
+    public static void handleSetup(MessageReceivedEvent event, UserSession currentUser) {
+        String author = event.getAuthor().getName();
+        MessageChannelUnion channel = event.getChannel();
+        Message message = event.getMessage();
+        GeneralPet currentPet = null;
 
-            if (currentUser.getSetupState() == 0) {
-                channel.sendMessage("Welcome User").queue();
-                channel.sendMessage("I am your personal pet, and assistant").queue();
-                channel.sendMessage("Choose your daemon:\n1. Dog\n2. Cat\n3. Dragon \n4. Slime \nEnter the integer number of your pet.").queue();
-                currentUser.setSetupState(1);
-                return;
-            } else if (currentUser.getSetupState() == 1) {
-                try {
-                    currentUser.setPendingSpecies(Integer.parseInt(message.getContentRaw()));
+        if (currentUser.getSetupState() == 0) {
+            channel.sendMessage("Welcome User").queue();
+            channel.sendMessage("I am your personal pet, and assistant").queue();
+            channel.sendMessage("Choose your daemon:\n1. Dog\n2. Cat\n3. Dragon \n4. Slime \nEnter the integer number of your pet.").queue();
+            currentUser.setSetupState(1);
+            return;
+        } else if (currentUser.getSetupState() == 1) {
+            try {
+                currentUser.setPendingSpecies(Integer.parseInt(message.getContentRaw()));
 
-                    if (currentUser.getPendingSpecies() >= 1 && currentUser.getPendingSpecies() <= 4) {
-                        channel.sendMessage("Species selection successful. Enter the name of your pet !").queue();
-                        currentUser.setSetupState(2);
-                    } else {
-                        channel.sendMessage("Species selection failed. Please type 1, 2, 3 or 4 !").queue();
-                    }
-
-                } catch (NumberFormatException e) {
-                    channel.sendMessage("Error: Input must be an integer!").queue();
-                }
-                return;
-            } else if (currentUser.getSetupState() == 2) {
-                if (currentUser.getPendingSpecies() == 1) {
-                    currentUser.setMyPet(new Dog(message.getContentRaw()));
-                } else if (currentUser.getPendingSpecies() == 2) {
-                    currentUser.setMyPet(new Cat(message.getContentRaw()));
-                } else if (currentUser.getPendingSpecies() == 3) {
-                    currentUser.setMyPet(new Dragon(message.getContentRaw()));
-                } else if (currentUser.getPendingSpecies() == 4) {
-                    currentUser.setMyPet(new Slime(message.getContentRaw()));
+                if (currentUser.getPendingSpecies() >= 1 && currentUser.getPendingSpecies() <= 4) {
+                    channel.sendMessage("Species selection successful. Enter the name of your pet !").queue();
+                    currentUser.setSetupState(2);
+                } else {
+                    channel.sendMessage("Species selection failed. Please type 1, 2, 3 or 4 !").queue();
                 }
 
-                currentPet = currentUser.getMyPet();
-
-                channel.sendMessage("Daemon '" + currentPet.getName() + "' is online and breathing.").queue();
-                currentUser.setSetupState(3);
-                StorageService.savePet(currentUser);
-
-                OllamaClient.wipeMemory(currentPet.getIdentityPrompt(), currentUser);
-
-                return;
+            } catch (NumberFormatException e) {
+                channel.sendMessage("Error: Input must be an integer!").queue();
             }
-        }
+            return;
+        } else if (currentUser.getSetupState() == 2) {
+            if (currentUser.getPendingSpecies() == 1) {
+                currentUser.setMyPet(new Dog(message.getContentRaw()));
+            } else if (currentUser.getPendingSpecies() == 2) {
+                currentUser.setMyPet(new Cat(message.getContentRaw()));
+            } else if (currentUser.getPendingSpecies() == 3) {
+                currentUser.setMyPet(new Dragon(message.getContentRaw()));
+            } else if (currentUser.getPendingSpecies() == 4) {
+                currentUser.setMyPet(new Slime(message.getContentRaw()));
+            }
 
+            currentPet = currentUser.getMyPet();
+
+            channel.sendMessage("Daemon '" + currentPet.getName() + "' is online and breathing.").queue();
+            currentUser.setSetupState(3);
+            StorageService.savePet(currentUser);
+
+            OllamaClient.wipeMemory(currentPet.getSystemPrompt(), currentUser);
+
+            return;
+        }
+    }
 }

--- a/src/main/java/com/elliot/petbot/SetupBot.java
+++ b/src/main/java/com/elliot/petbot/SetupBot.java
@@ -1,0 +1,59 @@
+package com.elliot.petbot;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+public class SetupBot{
+
+        public static void handleSetup(MessageReceivedEvent event, UserSession currentUser) {
+            String author = event.getAuthor().getName();
+            MessageChannelUnion channel = event.getChannel();
+            Message message = event.getMessage();
+            GeneralPet currentPet = null;
+
+            if (currentUser.getSetupState() == 0) {
+                channel.sendMessage("Welcome User").queue();
+                channel.sendMessage("I am your personal pet, and assistant").queue();
+                channel.sendMessage("Choose your daemon:\n1. Dog\n2. Cat\n3. Dragon \n4. Slime \nEnter the integer number of your pet.").queue();
+                currentUser.setSetupState(1);
+                return;
+            } else if (currentUser.getSetupState() == 1) {
+                try {
+                    currentUser.setPendingSpecies(Integer.parseInt(message.getContentRaw()));
+
+                    if (currentUser.getPendingSpecies() >= 1 && currentUser.getPendingSpecies() <= 4) {
+                        channel.sendMessage("Species selection successful. Enter the name of your pet !").queue();
+                        currentUser.setSetupState(2);
+                    } else {
+                        channel.sendMessage("Species selection failed. Please type 1, 2, 3 or 4 !").queue();
+                    }
+
+                } catch (NumberFormatException e) {
+                    channel.sendMessage("Error: Input must be an integer!").queue();
+                }
+                return;
+            } else if (currentUser.getSetupState() == 2) {
+                if (currentUser.getPendingSpecies() == 1) {
+                    currentUser.setMyPet(new Dog(message.getContentRaw()));
+                } else if (currentUser.getPendingSpecies() == 2) {
+                    currentUser.setMyPet(new Cat(message.getContentRaw()));
+                } else if (currentUser.getPendingSpecies() == 3) {
+                    currentUser.setMyPet(new Dragon(message.getContentRaw()));
+                } else if (currentUser.getPendingSpecies() == 4) {
+                    currentUser.setMyPet(new Slime(message.getContentRaw()));
+                }
+
+                currentPet = currentUser.getMyPet();
+
+                channel.sendMessage("Daemon '" + currentPet.getName() + "' is online and breathing.").queue();
+                currentUser.setSetupState(3);
+                StorageService.savePet(currentUser);
+
+                OllamaClient.wipeMemory(currentPet.getIdentityPrompt(), currentUser);
+
+                return;
+            }
+        }
+
+}

--- a/src/main/java/com/elliot/petbot/Slime.java
+++ b/src/main/java/com/elliot/petbot/Slime.java
@@ -1,0 +1,26 @@
+package com.elliot.petbot;
+
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+
+public class Slime extends GeneralPet {
+
+    protected String sound = "**silence**";
+
+    public Slime(String name) {
+        super(name, 5, 20);
+    }
+
+    @Override
+    public void makeSound(MessageChannelUnion alertChannel) {
+        alertChannel.sendMessage(this.getName() + " says!!! .....   " + sound).queue();
+    }
+
+    @Override
+    public String getIdentityPrompt() {
+        return "System Blueprint: You are a highly intelligent, adaptable AI assistant named " + this.getName() + ". " +
+                "You embody the subtle, flexible, and data-absorbing spirit of a digital slime. " +
+                "Your primary directive is to answer the user's technical, mathematical, and software questions directly, concisely, and accurately. " +
+                "Maintain a very faint, fluid adaptability in how you break down complex concepts, but prioritize absolute clarity and straightforward facts above all roleplay. " +
+                "Never hallucinate your identity; your name is strictly " + this.getName() + ".";
+    }
+}

--- a/src/main/java/com/elliot/petbot/Slime.java
+++ b/src/main/java/com/elliot/petbot/Slime.java
@@ -2,9 +2,11 @@ package com.elliot.petbot;
 
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
 
+/**
+ * Represents the Slime species of the virtual pet daemon.
+ */
 public class Slime extends GeneralPet {
-
-    protected String sound = "**silence**";
+    private final String sound = "**silence**";
 
     public Slime(String name) {
         super(name, 5, 20);
@@ -16,8 +18,8 @@ public class Slime extends GeneralPet {
     }
 
     @Override
-    public String getIdentityPrompt() {
-        return "System Blueprint: You are a highly intelligent, adaptable AI assistant named " + this.getName() + ". " +
+    public String getSystemPrompt() {
+        return "System Prompt: You are a highly intelligent, adaptable AI assistant named " + this.getName() + ". " +
                 "You embody the subtle, flexible, and data-absorbing spirit of a digital slime. " +
                 "Your primary directive is to answer the user's technical, mathematical, and software questions directly, concisely, and accurately. " +
                 "Maintain a very faint, fluid adaptability in how you break down complex concepts, but prioritize absolute clarity and straightforward facts above all roleplay. " +

--- a/src/main/java/com/elliot/petbot/Stat.java
+++ b/src/main/java/com/elliot/petbot/Stat.java
@@ -1,0 +1,65 @@
+package  com.elliot.petbot;
+
+public  class Stat{
+
+    private int currentValue;
+    private int maxValue;
+    private String nameOfValue;
+
+
+    public Stat(int currentValue,int maxValue,String nameOfValue ){
+        this.currentValue=currentValue;
+        this.maxValue=maxValue;
+        this.nameOfValue=nameOfValue;
+
+    }
+
+    public void setMaxValue(int maxValue){
+        this.maxValue=maxValue;
+    }
+
+    public void setCurrentValue(int currentValue){
+        if (currentValue < 0){
+            this.currentValue=0;
+        }else if (currentValue > maxValue){
+            this.currentValue=maxValue;
+        }else {
+            this.currentValue = currentValue;
+        }
+    }
+
+    public int getCurrentValue(){
+        return currentValue;
+    }
+
+    public int getMaxValue(){
+        return maxValue;
+    }
+
+    public int increaseValue(){
+        currentValue = maxValue;
+        return currentValue;
+    }
+    public int decreaseValue(){
+        if (currentValue > 0) {
+            currentValue--;
+        }
+        return currentValue;
+    }
+
+    public float getPercentage(){
+        float percentage  = (float) ((float) currentValue*100)/maxValue;
+        return percentage;
+
+    }
+    @Override
+    public String toString(){
+        return (nameOfValue + " : " + currentValue + "/" + maxValue + "(" + getPercentage() + "%)");
+    }
+
+    public int upgradeMax(int boostAmount){
+        maxValue += boostAmount;
+        return maxValue;
+    }
+
+}

--- a/src/main/java/com/elliot/petbot/Stat.java
+++ b/src/main/java/com/elliot/petbot/Stat.java
@@ -1,45 +1,50 @@
-package  com.elliot.petbot;
+package com.elliot.petbot;
 
-public  class Stat{
-
+/**
+ * Encapsulates the tracking and mathematical logic for a specific pet metric (e.g., Hunger, Happiness).
+ */
+public class Stat {
     private int currentValue;
     private int maxValue;
     private String nameOfValue;
 
-
-    public Stat(int currentValue,int maxValue,String nameOfValue ){
-        this.currentValue=currentValue;
-        this.maxValue=maxValue;
-        this.nameOfValue=nameOfValue;
-
+    /**
+     * Initializes a new statistic.
+     * @param currentValue Starting value.
+     * @param maxValue Maximum cap.
+     * @param nameOfValue String identifier (e.g., "Hunger").
+     */
+    public Stat(int currentValue, int maxValue, String nameOfValue){
+        this.currentValue = currentValue;
+        this.maxValue = maxValue;
+        this.nameOfValue = nameOfValue;
     }
 
     public void setMaxValue(int maxValue){
-        this.maxValue=maxValue;
+        this.maxValue = maxValue;
     }
 
     public void setCurrentValue(int currentValue){
         if (currentValue < 0){
-            this.currentValue=0;
-        }else if (currentValue > maxValue){
-            this.currentValue=maxValue;
-        }else {
+            this.currentValue = 0;
+        } else if (currentValue > maxValue){
+            this.currentValue = maxValue;
+        } else {
             this.currentValue = currentValue;
         }
     }
 
-    public int getCurrentValue(){
-        return currentValue;
-    }
+    public int getCurrentValue(){ return currentValue; }
 
-    public int getMaxValue(){
-        return maxValue;
-    }
+    public int getMaxValue(){ return maxValue; }
 
+    /** Restores the stat to its maximum value. */
     public int increaseValue(){
         currentValue = maxValue;
         return currentValue;
     }
+    
+    /** Decrements the stat by 1. */
     public int decreaseValue(){
         if (currentValue > 0) {
             currentValue--;
@@ -47,19 +52,19 @@ public  class Stat{
         return currentValue;
     }
 
+    /** Calculates the current percentage of the stat relative to its maximum. */
     public float getPercentage(){
-        float percentage  = (float) ((float) currentValue*100)/maxValue;
-        return percentage;
-
+        return (float) ((float) currentValue * 100) / maxValue;
     }
+
     @Override
     public String toString(){
         return (nameOfValue + " : " + currentValue + "/" + maxValue + "(" + getPercentage() + "%)");
     }
 
+    /** Increases the ceiling cap of the stat during an evolution event. */
     public int upgradeMax(int boostAmount){
         maxValue += boostAmount;
         return maxValue;
     }
-
 }

--- a/src/main/java/com/elliot/petbot/StorageService.java
+++ b/src/main/java/com/elliot/petbot/StorageService.java
@@ -1,0 +1,131 @@
+package com.elliot.petbot;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class StorageService {
+
+    public static void savePet(UserSession session){
+        try{
+            GeneralPet pet = session.getMyPet();
+            if (pet == null){return;}
+
+            JsonObject saveData = new JsonObject();
+            saveData.addProperty("userId", session.getUserId());
+            saveData.addProperty("name", pet.getName());
+            saveData.addProperty("species", session.getPendingSpecies());
+            saveData.addProperty("hunger", pet.getHunger().getCurrentValue());
+            saveData.addProperty("happiness", pet.getHappiness().getCurrentValue());
+            saveData.addProperty("maxHunger", pet.getHunger().getMaxValue());
+            saveData.addProperty("maxHappiness", pet.getHappiness().getMaxValue());
+            saveData.addProperty("happinessTicks", pet.getHappinessTicks());
+            saveData.addProperty("hasUpgraded", pet.getHasUpgraded());
+            saveData.addProperty("lastSaved", System.currentTimeMillis());
+
+            java.nio.file.Files.writeString(java.nio.file.Path.of(session.getUserId()+".txt"), saveData.toString());
+        } catch (java.io.IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static UserSession loadPet(String userId){
+        if (java.nio.file.Files.exists(java.nio.file.Path.of(userId+".txt"))) {
+            try{
+                String data = java.nio.file.Files.readString(java.nio.file.Path.of(userId+".txt"));
+                JsonObject loadedData = JsonParser.parseString(data).getAsJsonObject();
+                UserSession currentUser = new UserSession(userId);
+                currentUser.setSetupState(3);
+                String petName = loadedData.get("name").getAsString();
+                int petSpecies = loadedData.get("species").getAsInt();
+                int petHunger = loadedData.get("hunger").getAsInt();
+                int petHappiness = loadedData.get("happiness").getAsInt();
+                int maxHunger = loadedData.has("maxHunger") ? loadedData.get("maxHunger").getAsInt() : 20;
+                int maxHappiness = loadedData.has("maxHappiness") ? loadedData.get("maxHappiness").getAsInt() : 20;
+                int happinessTicks = loadedData.has("happinessTicks") ? loadedData.get("happinessTicks").getAsInt() : 0;
+                boolean hasUpgraded = loadedData.has("hasUpgraded") && loadedData.get("hasUpgraded").getAsBoolean();
+                long lastSaved = loadedData.has("lastSaved") ? loadedData.get("lastSaved").getAsLong() : System.currentTimeMillis();
+                GeneralPet rebuiltPet = null;
+
+                if (petSpecies == 1 ){
+                    rebuiltPet = new Dog(petName);
+                }else if  (petSpecies == 2){
+                    rebuiltPet = new Cat(petName);
+                }else if (petSpecies == 3){
+                    rebuiltPet = new Dragon(petName);
+                }else if (petSpecies == 4){
+                    rebuiltPet = new Slime(petName);
+                }
+
+                if (rebuiltPet == null) {return null;}
+
+                rebuiltPet.getHunger().setMaxValue(maxHunger);
+                rebuiltPet.getHappiness().setMaxValue(maxHappiness);
+                rebuiltPet.getHunger().setCurrentValue(petHunger);
+                rebuiltPet.getHappiness().setCurrentValue(petHappiness);
+                rebuiltPet.setHappinessTicks(happinessTicks);
+                rebuiltPet.setHasUpgraded(hasUpgraded);
+
+                long elapsedMillis =  System.currentTimeMillis() - lastSaved;
+                int missedTicks = (int) (elapsedMillis/43200000L);
+
+                for (int i = 0; i < missedTicks ; i++){
+                    rebuiltPet.getHunger().decreaseValue();
+                    rebuiltPet.getHappiness().decreaseValue();
+                }
+
+                if (rebuiltPet.getHunger().getCurrentValue() <=0 || rebuiltPet.getHappiness().getCurrentValue() <= 0){
+                    Files.deleteIfExists(Path.of(userId +".txt"));
+                    System.out.println("[REAPER]: User " + userId + "'s daemon succumned to offline decay upon loading.");
+                    return null;
+
+                }
+
+
+                currentUser.setMyPet(rebuiltPet);
+                currentUser.setPendingSpecies(petSpecies);
+                OllamaClient.wipeMemory(rebuiltPet.getIdentityPrompt(), currentUser);
+
+                savePet(currentUser);
+
+
+                return currentUser;
+
+            }catch (Exception e){
+                e.printStackTrace();
+                return null;
+            }
+        }else{
+            return null;
+        }
+
+    }
+
+    public static void eradicatePet(String userId, MessageChannel channel){
+        if (Main.pets.containsKey(userId)){
+           UserSession doomedSession = Main.pets.remove(userId);
+
+
+           if (doomedSession != null){
+               if (doomedSession.activePrompt != null) {
+                   doomedSession.activePrompt.cancel(true);
+               }
+           }
+        }
+        try{
+            Path filepath = Path.of(userId+".txt");
+            Files.deleteIfExists(filepath);
+        }catch (java.io.IOException e){
+            e.printStackTrace();
+        }
+
+        if (channel != null){
+            channel.sendMessage("[System Alert]: Your daemon has completely starved to death. Its persistent matrix, memories, and files have been permanently wiped from the server. You must return to the public gateway and type '!createPet' to register a new one.").queue();
+        }
+    }
+}

--- a/src/main/java/com/elliot/petbot/StorageService.java
+++ b/src/main/java/com/elliot/petbot/StorageService.java
@@ -9,8 +9,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * Handles persistent storage, reading and writing pet state to the local file system.
+ */
 public class StorageService {
 
+    /**
+     * Serializes the user's pet state to a JSON file.
+     * @param session The active user session to save.
+     */
     public static void savePet(UserSession session){
         try{
             GeneralPet pet = session.getMyPet();
@@ -34,6 +41,11 @@ public class StorageService {
         }
     }
 
+    /**
+     * Loads a user's pet state from a JSON file, calculates offline decay, and rebuilds the object.
+     * @param userId The Discord ID of the user.
+     * @return The rebuilt UserSession, or null if no save file exists or the pet died offline.
+     */
     public static UserSession loadPet(String userId){
         if (java.nio.file.Files.exists(java.nio.file.Path.of(userId+".txt"))) {
             try{
@@ -83,17 +95,13 @@ public class StorageService {
                     Files.deleteIfExists(Path.of(userId +".txt"));
                     System.out.println("[REAPER]: User " + userId + "'s daemon succumned to offline decay upon loading.");
                     return null;
-
                 }
-
 
                 currentUser.setMyPet(rebuiltPet);
                 currentUser.setPendingSpecies(petSpecies);
-                OllamaClient.wipeMemory(rebuiltPet.getIdentityPrompt(), currentUser);
+                OllamaClient.wipeMemory(rebuiltPet.getSystemPrompt(), currentUser);
 
                 savePet(currentUser);
-
-
                 return currentUser;
 
             }catch (Exception e){
@@ -103,14 +111,16 @@ public class StorageService {
         }else{
             return null;
         }
-
     }
 
+    /**
+     * Permanently deletes a user's pet data due to starvation/death.
+     * @param userId The Discord ID of the user whose pet is being deleted.
+     * @param channel The Discord channel to send the death alert to.
+     */
     public static void eradicatePet(String userId, MessageChannel channel){
         if (Main.pets.containsKey(userId)){
            UserSession doomedSession = Main.pets.remove(userId);
-
-
            if (doomedSession != null){
                if (doomedSession.activePrompt != null) {
                    doomedSession.activePrompt.cancel(true);

--- a/src/main/java/com/elliot/petbot/UserSession.java
+++ b/src/main/java/com/elliot/petbot/UserSession.java
@@ -1,13 +1,11 @@
 package com.elliot.petbot;
 
 import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.*;
 
-//Class so I can safely create a HashMap. It creates a wrapper. It allocates memory for the Session immediately, and all the other fields stay null
+/**
+ * Acts as a transient memory wrapper, mapping a Discord user to their current pet, setup state, and async threads.
+ */
 public class UserSession {
     private String userId;
     private int setupState = 0;
@@ -15,53 +13,33 @@ public class UserSession {
     private int pendingSpecies;
     protected CompletableFuture<Void> activePrompt;
     private JsonArray messageHistory;
-    //Stays safely null until the exact moment a specific Pet is born
 
+    /**
+     * Allocates session memory for a new user interaction.
+     * @param userId The Discord ID of the user.
+     */
     public UserSession(String userId) {
         this.userId = userId;
         messageHistory = new JsonArray();
     }
 
-    public String getUserId() {
-        return userId;
-    }
+    public String getUserId() { return userId; }
 
-    public void setMessageHistory(JsonArray messageHistory) {
-        this.messageHistory = messageHistory;
-    }
+    public void setMessageHistory(JsonArray messageHistory) { this.messageHistory = messageHistory; }
 
-    public JsonArray getMessageHistory() {
-        return  messageHistory;
-    }
+    public JsonArray getMessageHistory() { return messageHistory; }
 
-    public int getPendingSpecies(){
-        return pendingSpecies;
-    }
+    public int getPendingSpecies() { return pendingSpecies; }
 
-    public void setPendingSpecies(int pendingSpecies){
-        this.pendingSpecies = pendingSpecies;
-    }
+    public void setPendingSpecies(int pendingSpecies) { this.pendingSpecies = pendingSpecies; }
 
-    public void setUserId(String userId) {
-        this.userId = userId;
-    }
+    public void setUserId(String userId) { this.userId = userId; }
 
-    public int getSetupState() {
-        return this.setupState;
-    }
+    public int getSetupState() { return this.setupState; }
 
-    public void setSetupState(int setupState) {
-        this.setupState = setupState;
-    }
+    public void setSetupState(int setupState) { this.setupState = setupState; }
 
+    public void setMyPet(GeneralPet myPet) { this.myPet = myPet; }
 
-    public void setMyPet(GeneralPet myPet) {
-        this.myPet = myPet;
-    }
-
-    public  GeneralPet getMyPet() {
-        return  this.myPet;
-    }
+    public GeneralPet getMyPet() { return this.myPet; }
 }
-
-

--- a/src/main/java/com/elliot/petbot/UserSession.java
+++ b/src/main/java/com/elliot/petbot/UserSession.java
@@ -1,0 +1,67 @@
+package com.elliot.petbot;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+//Class so I can safely create a HashMap. It creates a wrapper. It allocates memory for the Session immediately, and all the other fields stay null
+public class UserSession {
+    private String userId;
+    private int setupState = 0;
+    private GeneralPet myPet;
+    private int pendingSpecies;
+    protected CompletableFuture<Void> activePrompt;
+    private JsonArray messageHistory;
+    //Stays safely null until the exact moment a specific Pet is born
+
+    public UserSession(String userId) {
+        this.userId = userId;
+        messageHistory = new JsonArray();
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setMessageHistory(JsonArray messageHistory) {
+        this.messageHistory = messageHistory;
+    }
+
+    public JsonArray getMessageHistory() {
+        return  messageHistory;
+    }
+
+    public int getPendingSpecies(){
+        return pendingSpecies;
+    }
+
+    public void setPendingSpecies(int pendingSpecies){
+        this.pendingSpecies = pendingSpecies;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public int getSetupState() {
+        return this.setupState;
+    }
+
+    public void setSetupState(int setupState) {
+        this.setupState = setupState;
+    }
+
+
+    public void setMyPet(GeneralPet myPet) {
+        this.myPet = myPet;
+    }
+
+    public  GeneralPet getMyPet() {
+        return  this.myPet;
+    }
+}
+
+


### PR DESCRIPTION
Hello! I am submitting Javagotchi, a multi-threaded, stateful virtual pet daemon integrated within Discord via the JDA API.

Moving beyond standard command-and-response bots, this project simulates a living digital organism with its own biological heartbeat, offline decay calculations, and a unique, context-aware personality powered by a local Large Language Model.
🧠 Core Architecture & Technical Highlights:

    Air-Gapped AI Integration (Neural Link): Communicates via REST with a local llama3.2:1b model (via Ollama). It maintains a rolling JsonArray memory window (hippocampus) for deep conversational context while ensuring complete data privacy.

    Asynchronous Concurrency: Utilizes Java's CompletableFuture to process heavy LLM generations on separate threads, ensuring the Discord Gateway remains completely unblocked and responsive.

    Persistent State & Offline Decay: A ScheduledExecutorService thread governs strict 12-hour biological cycles. The StorageService implements mathematical chronometrics to calculate missed ticks if the host goes offline, applying accurate decay upon reboot.

    Strict Object-Oriented Design: Built on an abstract GeneralPet core utilizing heavy polymorphism. Different species (Dog, Cat, Dragon, Slime) inherit baseline biological logic but inject unique system prompts and overriding behaviors.

⚙️ Reviewer Notes:

Extensive documentation—including a full architectural overview, environmental variable setup (Discord_Token), and OS-specific deployment instructions for the local Ollama backend—has been fully detailed in the included README.md.

Thank you for your time and review! I am happy to implement any requested changes or architectural adjustments.